### PR TITLE
Remove unused rasterio dependency, declare click/cligj directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ There is a [wealth of British Columbia geographic information available as open
 data](https://catalogue.data.gov.bc.ca/dataset?download_audience=Public),
 but most sources are available only via WFS - and the syntax to download WFS data via `ogr2ogr` and/or `curl/wget` can be awkward.
 
-This tool attempts to simplify downloads of BC geographic data and smoothly integrate with PostGIS and Python GIS tools like `geopandas`, `fiona` and `rasterio`. The tool only accesses geographic data [avialable via WFS](https://bcgov.github.io/data-publication/pages/tips_tricks_webservices.html) - for other BC open data, download the files directly with `requests` / `curl` / `ogr2ogr` / etc (or the [bcdata R package](https://github.com/bcgov/bcdata)).
+This tool attempts to simplify downloads of BC geographic data and smoothly integrate with PostGIS and Python GIS tools like `geopandas` and `fiona`. The tool only accesses geographic data [avialable via WFS](https://bcgov.github.io/data-publication/pages/tips_tricks_webservices.html) - for other BC open data, download the files directly with `requests` / `curl` / `ogr2ogr` / etc (or the [bcdata R package](https://github.com/bcgov/bcdata)).
 
 If downloads are failing, consult the [BCGov Data Systems and Services uptime monitor](https://uptime.com/statuspage/bcgov-dss) - this tool depends on BC Open Geospatial Web Services API at [openmaps.gov.bc.ca](https://openmaps.gov.bc.ca/geo/pub/ows?service=WFS&request=Getcapabilities) and the [BC Data Catalogue API](https://catalogue.data.gov.bc.ca/dataset/bc-data-catalogue-api). 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,12 @@ classifiers = [
     "Operating System :: OS Independent"
 ]
 dependencies = [
+    "click",
+    "cligj",
     "geoalchemy2",
     "geopandas",
     "owslib",
     "psycopg2-binary",
-    "rasterio",
     "requests",
     "sqlalchemy",
     "stamina"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 ]
 dependencies = [
     "click",
-    "cligj",
     "geoalchemy2",
     "geopandas",
     "owslib",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
+click>=8.0
+cligj>=0.5
 geoalchemy2>=0.15
 geopandas>=1.0
 owslib>=0.31
 psycopg2-binary>=2.9
-rasterio>=1.3
 requests>=2.32
 sqlalchemy>=2.0
 stamina>=24.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 click>=8.0
-cligj>=0.5
 geoalchemy2>=0.15
 geopandas>=1.0
 owslib>=0.31

--- a/src/bcdata/cli.py
+++ b/src/bcdata/cli.py
@@ -5,12 +5,25 @@ import re
 import sys
 
 import click
-from cligj import compact_opt, indent_opt, quiet_opt, verbose_opt
 
 import bcdata
 from bcdata.database import Database
 
 LOG_FORMAT = "%(asctime)s:%(levelname)s:%(name)s: %(message)s"
+
+# inlined from cligj (unmaintained), as per
+# https://github.com/rasterio/rasterio/pull/3364
+verbose_opt = click.option("--verbose", "-v", count=True, help="Increase verbosity.")
+
+quiet_opt = click.option("--quiet", "-q", count=True, help="Decrease verbosity.")
+
+indent_opt = click.option(
+    "--indent", type=int, default=None, help="Indentation level for JSON output"
+)
+
+compact_opt = click.option(
+    "--compact/--not-compact", default=False, help="Use compact separators (',', ':')."
+)
 
 
 def configure_logging(verbosity):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ def test_info_table():
     result = runner.invoke(cli, ["info", AIRPORTS_TABLE])
     assert result.exit_code == 0
     assert 'name": "{}"'.format(AIRPORTS_TABLE) in result.output
-    assert '"count": 455' in result.output
+    assert '"count": 451' in result.output
 
 
 def test_info_package():
@@ -33,7 +33,7 @@ def test_info_package():
     result = runner.invoke(cli, ["info", AIRPORTS_PACKAGE])
     assert result.exit_code == 0
     assert 'name": "{}"'.format(AIRPORTS_TABLE) in result.output
-    assert '"count": 455' in result.output
+    assert '"count": 451' in result.output
 
 
 def test_list():
@@ -47,7 +47,7 @@ def test_cat():
     runner = CliRunner()
     result = runner.invoke(cli, ["cat", AIRPORTS_TABLE])
     assert result.exit_code == 0
-    assert len(result.output.split("\n")) == 456
+    assert len(result.output.split("\n")) == 452
 
 
 def test_cat_query():


### PR DESCRIPTION
rasterio was never imported by bcdata, only listed as a dependency. Removing it exposed that cli.py imports click and cligj directly, which were only ever satisfied transitively via rasterio's own dependencies - newer rasterio releases no longer pull in cligj at all, so this was already broken on a fresh install of main.

Fixes #230