### PR TITLE
Add docker-compose.yml for local test database

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,10 +326,10 @@ Use some other tool to reproject the data as required.
 
 ## Development and testing
 
-`bc2pg` tests require database `postgresql://postgres@localhost:5432/test_bcdata` exists and has PostGIS installed:
+`bc2pg` tests require a PostGIS database, referenced via the `DATABASE_URL` environment variable (matching the image used in CI, see `.github/workflows/tests.yml`). Start one locally with `docker compose`:
 
-    psql -c "create database test_bcdata"
-    psql test_bcdata -c "create extension postgis"
+    $ docker compose up -d
+    $ export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 
 Create virtualenv and install `bcdata` in development mode:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  postgres:
+    image: postgis/postgis:17-3.5
+    environment:
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
Local test setup previously required manually creating a database and installing PostGIS by hand, with README instructions that had drifted out of sync with how tests actually read DATABASE_URL. Add a compose file using the same postgis image as CI, and update the README to match.