### PR TITLE
Guard airport-count tests against feature count drift

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import os
 
 from click.testing import CliRunner
 
+import bcdata
 from bcdata.cli import cli
 from bcdata.database import Database
 
@@ -16,24 +17,23 @@ BBOX_LL = "-123.396104,48.404465,-123.342588,48.425401"
 RIVERS_TABLE = "whse_basemapping.fwa_rivers_poly"
 ASSESSMENTS_TABLE = "whse_fish.pscis_assessment_svw"
 
-# Note that these tests depend on airport counts.
-# If airports are added to or removed from source layer, tests will fail
-
 
 def test_info_table():
     runner = CliRunner()
+    expected_count = bcdata.get_count(AIRPORTS_TABLE)
     result = runner.invoke(cli, ["info", AIRPORTS_TABLE])
     assert result.exit_code == 0
     assert 'name": "{}"'.format(AIRPORTS_TABLE) in result.output
-    assert '"count": 451' in result.output
+    assert '"count": {}'.format(expected_count) in result.output
 
 
 def test_info_package():
     runner = CliRunner()
+    expected_count = bcdata.get_count(AIRPORTS_TABLE)
     result = runner.invoke(cli, ["info", AIRPORTS_PACKAGE])
     assert result.exit_code == 0
     assert 'name": "{}"'.format(AIRPORTS_TABLE) in result.output
-    assert '"count": 451' in result.output
+    assert '"count": {}'.format(expected_count) in result.output
 
 
 def test_list():
@@ -45,9 +45,10 @@ def test_list():
 
 def test_cat():
     runner = CliRunner()
+    expected_count = bcdata.get_count(AIRPORTS_TABLE)
     result = runner.invoke(cli, ["cat", AIRPORTS_TABLE])
     assert result.exit_code == 0
-    assert len(result.output.split("\n")) == 452
+    assert len(result.output.split("\n")) == expected_count + 1
 
 
 def test_cat_query():


### PR DESCRIPTION
test_info_table, test_info_package, and test_cat asserted against a hardcoded snapshot of the live BC Airports WFS layer's feature count, which breaks whenever airports are added or removed upstream (as already happened once, 455 -> 451). Fetch the count live via bcdata.get_count() instead and assert against that.

Somewhat fixes #234 - other tests check feature counts (and require given feature names be present) but they are less vulnerable to changes.

