### PR TITLE
Handle zero-feature results in get_data() without crashing

### DIFF
--- a/src/bcdata/wfs.py
+++ b/src/bcdata/wfs.py
@@ -443,8 +443,10 @@ def get_data(
         gdf = pd.concat(results)
     elif len(results) == 1:
         gdf = results[0]
+    # generally all datasets should have records, but handle the case of zero results
+    # by creating an empty geodataframe
     else:
-        gdf = gpd.GeoDataFrame()
+        gdf = gpd.GeoDataFrame(geometry=[])
     if as_gdf:
         return gdf
     else:

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -81,6 +81,11 @@ def test_get_null_gdf():
     assert type(gdf) is GeoDataFrame
 
 
+def test_get_null_geojson():
+    data = bcdata.get_data(UTMZONES_KEY, query="UTM_ZONE=9999")
+    assert data == {"type": "FeatureCollection", "features": []}
+
+
 def test_get_data_small():
     data = bcdata.get_data(AIRPORTS_TABLE)
     assert data["type"] == "FeatureCollection"


### PR DESCRIPTION
When no data returned, construct empty gdf with an explicit empty geometry column so both as_gdf=True and as_gdf=False return a valid empty result rather than crashing.