### PR TITLE
Fix stamina retry pattern so retries actually happen on slow failures

### DIFF
--- a/src/bcdata/wfs.py
+++ b/src/bcdata/wfs.py
@@ -56,14 +56,42 @@ class ServiceException(Exception):
 RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
 
+def _rate_limit_backoff(response):
+    """Return the server-specified backoff (seconds) for a 429 response, if given.
+
+    Checks the standard Retry-After header as well as RateLimit-Reset, which
+    is what DataBC's Kong gateway sends. Returns None if neither is present
+    or parseable, in which case the caller should fall back to the default
+    exponential backoff.
+    """
+    for header in ("Retry-After", "RateLimit-Reset"):
+        value = response.headers.get(header)
+        if value is not None:
+            try:
+                return float(value)
+            except ValueError:
+                continue
+    return None
+
+
 def _is_retryable(exc):
     """Decide whether a request exception is worth retrying.
 
     Used as the ``on=`` hook for @stamina.retry - see
     https://stamina.hynek.me/en/stable/tutorial.html
+
+    Returning a float instead of True overrides the default backoff, which
+    is used to honour a 429 response's server-specified retry delay.
     """
     if isinstance(exc, requests.HTTPError):
-        return exc.response is not None and exc.response.status_code in RETRYABLE_STATUS_CODES
+        response = exc.response
+        if response is None or response.status_code not in RETRYABLE_STATUS_CODES:
+            return False
+        if response.status_code == 429:
+            backoff = _rate_limit_backoff(response)
+            if backoff is not None:
+                return backoff
+        return True
     return isinstance(exc, (requests.ConnectionError, requests.Timeout))
 
 
@@ -156,7 +184,15 @@ class BCWFS:
             log.error(f"Response headers: {r.headers}")
             log.error(f"Response text: {r.text}")
             raise ServiceException(r.text)  # presumed request error
-        if r.status_code in RETRYABLE_STATUS_CODES:
+        if r.status_code == 429:
+            backoff = _rate_limit_backoff(r)
+            if backoff is not None:
+                log.warning(
+                    f"Rate limited by DataBC WFS, backing off for {backoff}s before retrying"
+                )
+            else:
+                log.warning("Rate limited by DataBC WFS, retrying")
+        elif r.status_code in RETRYABLE_STATUS_CODES:
             log.warning(f"HTTP error: {r.status_code}, retrying")
             log.warning(f"Response headers: {r.headers}")
             log.warning(f"Response text: {r.text}")

--- a/src/bcdata/wfs.py
+++ b/src/bcdata/wfs.py
@@ -51,6 +51,22 @@ class ServiceException(Exception):
     pass
 
 
+# status codes worth retrying - 5xx are presumed transient service errors,
+# 429 is DataBC's WFS telling us we're rate limited
+RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+
+def _is_retryable(exc):
+    """Decide whether a request exception is worth retrying.
+
+    Used as the ``on=`` hook for @stamina.retry - see
+    https://stamina.hynek.me/en/stable/tutorial.html
+    """
+    if isinstance(exc, requests.HTTPError):
+        return exc.response is not None and exc.response.status_code in RETRYABLE_STATUS_CODES
+    return isinstance(exc, (requests.ConnectionError, requests.Timeout))
+
+
 class BCWFS:
     """Wrapper around web feature service"""
 
@@ -101,7 +117,9 @@ class BCWFS:
                 or os.stat(cache_file).st_size == 0
             )
 
-    @stamina.retry(on=requests.HTTPError, timeout=60)
+    @stamina.retry(
+        on=(requests.HTTPError, requests.ConnectionError, requests.Timeout), attempts=5, timeout=300
+    )
     def _request_schema(self, table):
         schema = wfs_schema.get_schema(
             "https://openmaps.gov.bc.ca/geo/pub/ows",
@@ -110,7 +128,9 @@ class BCWFS:
         )
         return schema
 
-    @stamina.retry(on=requests.HTTPError, timeout=60)
+    @stamina.retry(
+        on=(requests.HTTPError, requests.ConnectionError, requests.Timeout), attempts=5, timeout=300
+    )
     def _request_capabilities(self):
         capabilities = ET.tostring(
             wfs200.WebFeatureService_2_0_0(self.ows_url, "2.0.0", None, False)._capabilities,
@@ -118,7 +138,31 @@ class BCWFS:
         )
         return capabilities
 
-    @stamina.retry(on=requests.HTTPError, timeout=60)
+    @stamina.retry(on=_is_retryable, attempts=5, timeout=300)
+    def _request(self, url, params=None, silent=False):
+        """Submit a request to DataBC WFS and return the raw response.
+
+        The WFS gateway itself can take up to ~60s to fail with a 504, so
+        the retry timeout above is sized to fit several such attempts
+        rather than being exhausted by a single one.
+        """
+        r = requests.get(url, params=params, headers=self.request_headers, timeout=(10, 65))
+        if not silent:
+            log.info(r.url)
+        else:
+            log.debug(r.url)
+        if r.status_code in [400, 401, 404]:
+            log.error(f"HTTP error {r.status_code}")
+            log.error(f"Response headers: {r.headers}")
+            log.error(f"Response text: {r.text}")
+            raise ServiceException(r.text)  # presumed request error
+        if r.status_code in RETRYABLE_STATUS_CODES:
+            log.warning(f"HTTP error: {r.status_code}, retrying")
+            log.warning(f"Response headers: {r.headers}")
+            log.warning(f"Response text: {r.text}")
+        r.raise_for_status()
+        return r
+
     def _request_count(self, table, query=None, bounds=None, bounds_crs=None, geom_column=None):
         payload = {
             "service": "WFS",
@@ -135,60 +179,16 @@ class BCWFS:
                 bounds_crs=bounds_crs,
                 geom_column=geom_column,
             )
-
-        r = requests.get(self.wfs_url, params=payload, headers=self.request_headers)
-        log.debug(r.url)
-        if r.status_code in [400, 401, 404]:
-            log.error(f"HTTP error {r.status_code}")
-            log.error(f"Response headers: {r.headers}")
-            log.error(f"Response text: {r.text}")
-            raise ServiceException(r.text)  # presumed request error
-        elif r.status_code in [500, 502, 503, 504]:  # presumed serivce error, retry
-            log.warning(f"HTTP error: {r.status_code}, retrying")
-            log.warning(f"Response headers: {r.headers}")
-            log.warning(f"Response text: {r.text}")
-            r.raise_for_status()
+        r = self._request(self.wfs_url, params=payload, silent=True)
         return int(ET.fromstring(r.text).attrib["numberMatched"])
 
-    @stamina.retry(on=requests.HTTPError, timeout=60)
     def _request_features(self, url, silent=False):
-        """Submit a getfeature request to DataBC WFS and return feature collection"""
-        r = requests.get(url, headers=self.request_headers)
-        if not silent:
-            log.info(r.url)
-        else:
-            log.debug(r.url)
-        if r.status_code in [400, 401, 404]:
-            log.error(f"HTTP error {r.status_code}")
-            log.error(f"Response headers: {r.headers}")
-            log.error(f"Response text: {r.text}")
-            raise ServiceException(r.text)  # presumed request error
-        elif r.status_code in [500, 502, 503, 504]:  # presumed serivce error, retry
-            log.warning(f"HTTP error: {r.status_code}")
-            log.warning(f"Response headers: {r.headers}")
-            log.warning(f"Response text: {r.text}")
-            r.raise_for_status()
-        return r.json()["features"]
+        """Submit a getfeature request to DataBC WFS and return features"""
+        return self._request(url, silent=silent).json()["features"]
 
-    @stamina.retry(on=requests.HTTPError, timeout=60)
     def _request_featurecollection(self, url, silent=False):
         """Submit a getfeature request to DataBC WFS and return feature collection"""
-        r = requests.get(url, headers=self.request_headers)
-        if not silent:
-            log.info(r.url)
-        else:
-            log.debug(r.url)
-        if r.status_code in [400, 401, 404]:
-            log.error(f"HTTP error {r.status_code}")
-            log.error(f"Response headers: {r.headers}")
-            log.error(f"Response text: {r.text}")
-            raise ServiceException(r.text)  # presumed request error
-        elif r.status_code in [500, 502, 503, 504]:  # presumed serivce error, retry
-            log.warning(f"HTTP error: {r.status_code}")
-            log.warning(f"Response headers: {r.headers}")
-            log.warning(f"Response text: {r.text}")
-            r.raise_for_status()
-        return r.json()
+        return self._request(url, silent=silent).json()
 
     def build_bounds_filter(self, query, bounds, bounds_crs, geom_column):
         """The bbox param shortcut is mutually exclusive with CQL_FILTER,

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -35,6 +35,34 @@ def test_http_error_404():
             bcdata.get_data(AIRPORTS_TABLE)
 
 
+def _http_error(status_code):
+    response = requests.Response()
+    response.status_code = status_code
+    return requests.HTTPError(response=response)
+
+
+def test_is_retryable_5xx_and_429():
+    """5xx (presumed transient service errors) and 429 (rate limited) are retried"""
+    for code in (429, 500, 502, 503, 504):
+        assert bcdata.wfs._is_retryable(_http_error(code)) is True
+
+
+def test_is_retryable_4xx_not_retried():
+    """4xx client errors (other than 429) are not retried"""
+    for code in (400, 401, 404):
+        assert bcdata.wfs._is_retryable(_http_error(code)) is False
+
+
+def test_is_retryable_connection_and_timeout_errors():
+    """Connection/timeout failures are also worth retrying, not just bad HTTP responses"""
+    assert bcdata.wfs._is_retryable(requests.ConnectionError()) is True
+    assert bcdata.wfs._is_retryable(requests.Timeout()) is True
+
+
+def test_is_retryable_other_exceptions_not_retried():
+    assert bcdata.wfs._is_retryable(ValueError("nope")) is False
+
+
 def test_validate_table_lowercase():
     table = bcdata.validate_name(AIRPORTS_TABLE.lower())
     assert table == AIRPORTS_TABLE

--- a/tests/test_wfs.py
+++ b/tests/test_wfs.py
@@ -59,6 +59,33 @@ def test_is_retryable_connection_and_timeout_errors():
     assert bcdata.wfs._is_retryable(requests.Timeout()) is True
 
 
+def test_is_retryable_429_without_headers_uses_default_backoff():
+    assert bcdata.wfs._is_retryable(_http_error(429)) is True
+
+
+def test_is_retryable_429_honours_retry_after_header():
+    response = requests.Response()
+    response.status_code = 429
+    response.headers["Retry-After"] = "12"
+    backoff = bcdata.wfs._is_retryable(requests.HTTPError(response=response))
+    assert backoff == 12.0
+
+
+def test_is_retryable_429_honours_ratelimit_reset_header():
+    """DataBC's Kong gateway sends RateLimit-Reset rather than Retry-After"""
+    response = requests.Response()
+    response.status_code = 429
+    response.headers["RateLimit-Reset"] = "5"
+    backoff = bcdata.wfs._is_retryable(requests.HTTPError(response=response))
+    assert backoff == 5.0
+
+
+def test_rate_limit_backoff_unparseable_header_falls_back_to_none():
+    response = requests.Response()
+    response.headers["Retry-After"] = "Wed, 21 Oct 2026 07:28:00 GMT"
+    assert bcdata.wfs._rate_limit_backoff(response) is None
+
+
 def test_is_retryable_other_exceptions_not_retried():
     assert bcdata.wfs._is_retryable(ValueError("nope")) is False
 


### PR DESCRIPTION
The WFS gateway itself can take up to ~60s to fail with a 504. Since stamina's timeout= is a cumulative deadline across all retries (not per-attempt), the previous timeout=60 was exhausted by a single slow attempt, leaving no budget for any actual retry - matching the reported "retry/stamina not working" symptom.

- Consolidate _request_count/_request_features/_request_featurecollection's duplicated request+status-handling into one _request() method, with retry-worthiness decided via a stamina on= callable (_is_retryable) instead of which branch happens to call raise_for_status()
- Retry on 429 (rate limited) in addition to 5xx, and on requests.ConnectionError/Timeout, not just HTTPError
- Add an HTTP-level timeout to the request itself, so a truly hung connection raises instead of blocking forever
- Size the retry budget (attempts=5, timeout=300) to fit several real attempts against a service that can be this slow per-attempt
- Widen _request_schema/_request_capabilities's retry to also catch connection/timeout errors

Tests: added direct unit tests for _is_retryable() covering 5xx, 429, 4xx, and connection/timeout errors. Per stamina's testing docs (https://stamina.hynek.me/en/stable/testing.html), decorator-based retries should rely on stamina.set_active(False) in tests (already in place session-wide here) rather than asserting retry-loop mechanics via set_testing() - that's stamina's job to guarantee, not ours to re-test.

Fixes #215