### PR TITLE
Fix/wfs connect timeout 246

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 Changes
 =======
 
+0.17.1 (2026-08-)
+------------------
+- remove 10s connection timeout (#246)
+
 0.17.0 (2026-08-18)
 ------------------
 - drop support for Python 3.9

--- a/src/bcdata/__init__.py
+++ b/src/bcdata/__init__.py
@@ -21,4 +21,4 @@ else:
     raise ConnectionError(f"Failed to download primary key database at {PRIMARY_KEY_DB_URL}")
     primary_keys = {}
 
-__version__ = "0.17.0"
+__version__ = "0.17.1dev0"

--- a/src/bcdata/wfs.py
+++ b/src/bcdata/wfs.py
@@ -173,8 +173,15 @@ class BCWFS:
         The WFS gateway itself can take up to ~60s to fail with a 504, so
         the retry timeout above is sized to fit several such attempts
         rather than being exhausted by a single one.
+
+        No connect timeout is set (matching requests/urllib3's own default
+        of blocking until the OS gives up) - a hardcoded 10s connect timeout
+        was observed tripping on GitHub-hosted runners, whose handshake to
+        openmaps.gov.bc.ca can exceed that (see issue #246). The read
+        timeout stays bounded so a connected-but-hanging server is still
+        caught.
         """
-        r = requests.get(url, params=params, headers=self.request_headers, timeout=(10, 65))
+        r = requests.get(url, params=params, headers=self.request_headers, timeout=(None, 65))
         if not silent:
             log.info(r.url)
         else:


### PR DESCRIPTION
should fix primary download issue in #246 but I'm not yet sure why the catalogue is refusing connections to GHA runners.